### PR TITLE
adding a dockerfile and skip compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+COPY wcpctl.py /app/wcpctl.py
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "./wcpctl.py" ]


### PR DESCRIPTION
- adding a dockerfile for easier use

- added an optional variable to skip the cluster compatibility checks, this is due to an issue if you have a mixed environment with nsxt and VDS. you can get around this if you skip the compatibility check.