### PR TITLE
Moving the shebang to the first line of the script

### DIFF
--- a/wcpctl.py
+++ b/wcpctl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # “Copyright 2020 VMware, Inc.”
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
@@ -12,7 +14,6 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#!/usr/bin/env python3
 import requests
 import json
 import time


### PR DESCRIPTION
I had to do this to prevent import errors (and other errors) when running this script by a shell